### PR TITLE
Add robot_self_filter namespace before bodies and shapes namespace.

### DIFF
--- a/include/robot_self_filter/bodies.h
+++ b/include/robot_self_filter/bodies.h
@@ -52,7 +52,8 @@
    arms, for example).
 */
 
-
+namespace robot_self_filter
+{
 namespace bodies
 {
     
@@ -408,5 +409,5 @@ namespace bodies
     void mergeBoundingSpheres(const std::vector<BoundingSphere> &spheres, BoundingSphere &mergedSphere);
     
 }
-
+}
 #endif

--- a/include/robot_self_filter/shapes.h
+++ b/include/robot_self_filter/shapes.h
@@ -44,7 +44,8 @@
 /** Definition of various shapes. No properties such as position are
     included. These are simply the descriptions and dimensions of
     shapes. */
-
+namespace robot_self_filter
+{
 namespace shapes
 {
     
@@ -254,4 +255,5 @@ namespace shapes
     
 }
 
+}
 #endif

--- a/src/bodies.cpp
+++ b/src/bodies.cpp
@@ -41,6 +41,8 @@
 #include <iostream>
 #include <cmath>
 
+namespace robot_self_filter
+{
 bodies::Body* bodies::createBodyFromShape(const shapes::Shape *shape)
 {
     Body *body = NULL;
@@ -986,4 +988,6 @@ bool bodies::ConvexMesh::intersectsRay(const tf::Vector3& origin, const tf::Vect
     }
     
     return result;
+}
+  
 }

--- a/src/load_mesh.cpp
+++ b/src/load_mesh.cpp
@@ -56,7 +56,8 @@
 
 
 // \author Ioan Sucan ;  based on stl_to_mesh 
-
+namespace robot_self_filter
+{
 namespace shapes
 {
 
@@ -556,4 +557,5 @@ namespace shapes
 	return result;
     }
     
+}
 }

--- a/src/self_filter.cpp
+++ b/src/self_filter.cpp
@@ -40,6 +40,8 @@
 #include <tf/message_filter.h>
 #include <message_filters/subscriber.h>
 
+namespace robot_self_filter
+{
 class SelfFilter
 {
 public:
@@ -188,14 +190,14 @@ private:
   ros::Subscriber                                       no_filter_sub_;
   
 };
-
+}
     
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "self_filter");
   
   ros::NodeHandle nh("~");
-  SelfFilter s;
+  robot_self_filter::SelfFilter s;
   ros::spin();
     
   return 0;

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -35,6 +35,8 @@
 /** \author Ioan Sucan */
 
 #include "robot_self_filter/shapes.h"
+namespace robot_self_filter
+{
 
 shapes::Shape* shapes::cloneShape(const shapes::Shape *shape)
 {
@@ -86,4 +88,6 @@ shapes::StaticShape* shapes::cloneShape(const shapes::StaticShape *shape)
     }
     
     return result;
+}
+
 }


### PR DESCRIPTION
indigo port of https://github.com/PR2/robot_self_filter/pull/4

geometric_shapes package also provides bodies and shapes namespace
and same classes and functions. If a program is linked with
geometric_shapes and robot_self_filter, it may cause strange behavior
because of symbol confliction.
