### PR TITLE
Minor changes to indigo-devel CMake allow this to be used in kinetic and indigo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robot_self_filter)
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+endif()
+
+
 find_package(PkgConfig REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS signals)
@@ -40,7 +45,7 @@ find_package(catkin REQUIRED COMPONENTS roscpp tf filters sensor_msgs urdf roscp
 
 catkin_package(
     DEPENDS bullet
-    CATKIN-DEPENDS roscpp tf filters sensor_msgs urdf resource_retriever visualization_msgs pcl_ros
+    CATKIN_DEPENDS roscpp tf filters sensor_msgs urdf resource_retriever visualization_msgs pcl_ros
     INCLUDE_DIRS include
     LIBRARIES robot_geometric_shapes ${PROJECT_NAME}
 )


### PR DESCRIPTION
I still needed this package, despite the fact that its being released via the Debian packages anymore.  I forked and made the simple changes in the CMakefile that allow this to run in 14.04 or 16.04 with Indigo, Jade, and Kinetic.