### PR TITLE
depends on tinyxml and link against it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,9 @@ else()
 endif()
 
 
-find_package(catkin REQUIRED COMPONENTS roscpp tf filters sensor_msgs urdf roscpp resource_retriever visualization_msgs pcl_ros)
+find_package(catkin REQUIRED COMPONENTS roscpp tf filters sensor_msgs urdf roscpp resource_retriever visualization_msgs pcl_ros cmake_modules)
+
+find_package(TinyXML REQUIRED)
 
 catkin_package(
     DEPENDS bullet
@@ -65,8 +67,8 @@ add_executable(self_filter src/self_filter.cpp)
 target_link_libraries(self_filter ${PROJECT_NAME})
 target_link_libraries(self_filter robot_geometric_shapes  assimp)
 
-include_directories(include ${bullet_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
-target_link_libraries(robot_geometric_shapes ${bullet_LIBRARIES} ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES}  assimp)
+include_directories(include ${bullet_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+target_link_libraries(robot_geometric_shapes ${bullet_LIBRARIES} ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES} ${TinyXML_LIBRARIES} assimp)
 
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>cmake_modules</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>filters</build_depend>
@@ -22,6 +23,7 @@
   <build_depend>visualization_msgs</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>assimp-dev</build_depend>
+  <build_depend>tinyxml</build_depend>
   
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
@@ -33,6 +35,7 @@
   <run_depend>visualization_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>assimp</run_depend>
+  <run_depend>tinyxml</run_depend>
   <!-- <test_depend>roscpp</test_depend> -->
   <!-- <test_depend>tf</test_depend> -->
   <!-- <test_depend>filters</test_depend> -->


### PR DESCRIPTION
This package uses tinyxml symbols ([here](https://github.com/PR2/robot_self_filter/blob/5c2c42be6f7740afcf60068137c381df08c6f84d/src/load_mesh.cpp#L42) and [here](https://github.com/PR2/robot_self_filter/blob/5c2c42be6f7740afcf60068137c381df08c6f84d/src/load_mesh.cpp#L207) for example) without declaring a dependency on it. This can lead to breakage if the downstream packages decide to switch to tinyxml2. This PR ensures that tinyxml is found and linked against